### PR TITLE
Detect `@use`, not `@import` in svelte.config.js

### DIFF
--- a/__detect.js
+++ b/__detect.js
@@ -54,7 +54,7 @@ export const heuristics = [
 			/** @param {string} text */
 			const preprocessIsProbablySetup = (text) => {
 				if (!text.includes("additionalData")) return false;
-				if (!text.includes("@import")) return false;
+				if (!text.includes("@use")) return false;
 				if (!text.includes("src/variables.scss")) return false;
 
 				return true;


### PR DESCRIPTION
Fixes https://github.com/svelte-add/svelte-add/issues/176

Prior to this change, I also ran tests in `svelte-add` with `const addersToTest = ["scss","bulma"];` in `one-adder.js`. Confirmed that:

- Prior to change, tests failed
- After the change, tests passed.

So it really is just a one line fix.

Let me know if I'm missing any additional testing/organizational points - haven't used pnpm in a complex project before and I wouldn't be surprised if I'm missing something.